### PR TITLE
Add title of shortcuts for Linux .desktop files

### DIFF
--- a/desktop_file/Args.py
+++ b/desktop_file/Args.py
@@ -11,7 +11,8 @@ class Args:
                         Arg("-c", "--comment", 1),
                         Arg("-i", "--icon", 1),
                         Arg("-n", "--index", 1),
-                        Arg("-t", "--categories", 1)]
+                        Arg("-t", "--categories", 1),
+                        Arg("-s", "--title", 1)]
         self.invalidValue = "invalid rarg rvalue"
         self.invalidArg = "invalid argument rarg"
     

--- a/desktop_file/LinuxShortcut.py
+++ b/desktop_file/LinuxShortcut.py
@@ -43,8 +43,8 @@ class LinuxShortcut:
         self.name = name
         self.path = os.path.join(path, name) + ".desktop"
         self.file = open(self.path, "w")
-        self.file.write("[Desktop Entry]\nType=Application\nName=" + self.name + "\nExec=" + self.execFile + "\n")
-        self.attributes = {"Path": None, "Comment": None, "Icon": None, "Categories": None}
+        self.file.write("[Desktop Entry]\nType=Application\nExec=" + self.execFile + "\n")
+        self.attributes = {"Path": None, "Comment": None, "Icon": None, "Categories": None, "Name": self.name}
     
     def setWorkingDirectory(self, directory):
         self.attributes["Path"] = directory
@@ -57,6 +57,9 @@ class LinuxShortcut:
     
     def setCategories(self, categories):
         self.attributes["Categories"] = categories
+
+    def setTitle(self, title):
+        self.attributes["Name"] = title
     
     def save(self):
         for attrib in self.attributes:

--- a/desktop_file/WindowsShortcut.py
+++ b/desktop_file/WindowsShortcut.py
@@ -41,6 +41,9 @@ class WindowsShortcut:
     
     def setCategories(self, categories):
         pass
+
+    def setTitle(self, title):
+        pass
     
     def save(self):
         if not os.path.exists(self.execFile):

--- a/desktop_file/__main__.py
+++ b/desktop_file/__main__.py
@@ -15,6 +15,7 @@ class Main:
         icon = None
         index = 0
         categories = None
+        title = None
         for arg in self.format[0]:
             try:
                 if arg[0] == "--help":
@@ -32,6 +33,8 @@ class Main:
                     index = arg[1][0]
                 if arg[0] == "--categories":
                     categories = arg[1][0]
+                if arg[0] == "--title":
+                    title = arg[1][0]
             except IndexError:
                 print("A parameter must be provided for \"" + arg[0] + "\".")
                 self.args.exit()
@@ -51,6 +54,7 @@ class Main:
             self.setProp(workpath, shortcut.setWorkingDirectory)
             self.setProp(comment, shortcut.setComment)
             self.setProp(categories, shortcut.setCategories)
+            self.setProp(title, shortcut.setTitle)
             if icon != None:
                 shortcut.setIcon(icon, index)
             shortcut.save()

--- a/desktop_file/help.txt
+++ b/desktop_file/help.txt
@@ -10,3 +10,4 @@ Options:
 Platform specific options:
     -n  --index         INDEX       Index of the icon that it should have only affects windows lnk files
     -t  --categories    CATEGORIES  Categories the file should be listed in only affects linux desktop files
+    -s  --title         TITLE       Title of shortcut only affects linux desktop files


### PR DESCRIPTION
New argument -s/--title. When used, will set the parameter `Name` in the
output desktop file. The reason in that the title of the shortcut is
often more verbose than the name of the .desktop file.

If no title is set. The name of the shortcut will be used as the default
value.